### PR TITLE
Client - generate JS code from Solidity components using ethers.js

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -11,6 +11,7 @@
     "@babel/polyfill": "^7.0.0-rc.1",
     "@fortawesome/fontawesome-free": "^5.4.2",
     "dagre": "^0.8.2",
+    "ethers": "^4.0.26",
     "jquery": "^3.3.1",
     "ramda": "^0.25.0",
     "register-service-worker": "^1.0.0",

--- a/client/src/components/pipeapp/PipeApp.vue
+++ b/client/src/components/pipeapp/PipeApp.vue
@@ -104,6 +104,8 @@
 </template>
 
 <script>
+import { ethers } from 'ethers';
+window.ethers = ethers;
 export default {
     props: ['contractSource', 'graphSource', 'jsSource', 'deploymentInfo'],
     methods: {

--- a/client/src/components/pipecanvas/pipecanvaslib.js
+++ b/client/src/components/pipecanvas/pipecanvaslib.js
@@ -1472,6 +1472,22 @@ class GraphVisitor{
     }
 
     genGraph(g){
+        let cannotBeGenerated = Object.values(g).find((funcObject) => {
+            if (!funcObject.func.pclass.type) return false;
+            return (
+                funcObject.func.pclass.type != this.ops.pclassType &&
+                this.ops.pclassType === visOptions.solidity.pclassType
+            );
+        });
+        if (cannotBeGenerated) {
+            this.genF[grIndex] = '';
+            this.in = [];
+            this.out = [];
+            this.genConstr1 = [];
+            this.genConstr2 = [];
+            this.genConstr3 = [];
+            return;
+        }
         let ini = this.genF[grIndex]
 
         // Generating pipeline function definition (inputs + modifiers)

--- a/client/src/components/pipecanvas/pipecanvaslib.js
+++ b/client/src/components/pipecanvas/pipecanvaslib.js
@@ -1500,9 +1500,7 @@ class GraphVisitor{
         // Generating function return
         this.genF2[grIndex] = ""
         if (this.out.length >0){
-            this.genF2[grIndex] = this.ops.function_ret2
-            this.genF2[grIndex] += this.ops.function_ret21(this.out)
-            this.genF2[grIndex] += this.ops.function_ret3
+            this.genF2[grIndex] += this.ops.function_ret2(this.out);
         }
 
         // Code generation ends here
@@ -1688,9 +1686,7 @@ interface PipeProxy {
         "function_ret0": " returns (",
         "function_ret1": ")",
         // actual function return
-        "function_ret2": "return (",
-        "function_ret21": (outs) => outs.join(", "),
-        "function_ret3": ");\n",
+        "function_ret2": (outs) => `return (${outs.join(", ")});\n`,
         // input format
         "function_in": (type, name) => `${type} ${name}`,
         // outputs format
@@ -1744,9 +1740,10 @@ const web3 = undefined;`,
         "function_ret0": "",
         "function_ret1": "",
         // actual function return
-        "function_ret2": "\n    return ",
-        "function_ret21": (outs) => `{${outs.join(", ")}}`,
-        "function_ret3": ";\n",
+        "function_ret2": (outs) => `
+    console.log(${outs.join(", ")});
+    return {${outs.join(", ")}};
+`,
         // function end
         "function_ret4": `
 })`,

--- a/client/src/components/pipecanvas/pipecanvaslib.js
+++ b/client/src/components/pipecanvas/pipecanvaslib.js
@@ -1674,7 +1674,6 @@ interface PipeProxy {
         returns (bytes);
 }
 `,
-
         "contract_p0": "\ncontract PipedContract",
         "contract_p1": " {\n    PipeProxy public pipe_proxy;\n",
         "contract_p2": "}\n",
@@ -1695,7 +1694,6 @@ interface PipeProxy {
         // function end
         "function_ret4": "}",
         "function_p2": " {\n    bytes4 signature42;\n    bytes memory input42;\n    bytes memory answer42;\n    uint wei_value = msg.value;\n    address tx_sender = msg.sender;\n",
-
         "sigFunc1": "signature42 = bytes4(keccak256(\"",
         "sigFunc2": "\"));",
         "inputSig1": "input42 = abi.encodeWithSelector(signature42,",
@@ -1719,8 +1717,6 @@ interface PipeProxy {
             pipe_proxy = PipeProxy(_pipe_proxy);
         `,
         "const3": "}\n",
-
-
     },
     js: {
         type: "source",
@@ -1758,8 +1754,6 @@ const web3 = undefined;`,
         "function_p2": `
     let result;
 `,
-
-
         "sigFunc1": "",
         "sigFunc2": "",
         "inputSig1": "",
@@ -1777,14 +1771,7 @@ const web3 = undefined;`,
         "const1": "",
         "const2": ``,
         "const3": "",
-
-
-
-
-
-
     },
-
     graphRender: {
         type: "visual"
     }

--- a/client/src/components/pipecanvas/pipecanvaslib.js
+++ b/client/src/components/pipecanvas/pipecanvaslib.js
@@ -11,6 +11,8 @@ const R = require('ramda');
 
 const STRIP_COMMENTS = /((\/\/.*$)|(\/\*[\s\S]*?\*\/))/mg;
 const ARGUMENT_NAMES = /([^\s,]+)/g;
+const UNNAMED_INPUT = 'i_unnamed';
+const UNNAMED_OUTPUT = 'o_unnamed';
 
 function getParamNames(func) {
     const fnStr = func.toString().replace(STRIP_COMMENTS, '');
@@ -1521,10 +1523,8 @@ class GraphVisitor{
 
         if (funcObj.func.pfunction.gapi.type == "port") {
             this.genFuncIO(funcObj);
-        } else if (
-            funcObj.func.pfunction.gapi.type == "function" &&
-            funcObj.func.pclass.type  === this.ops.pclassType
-        ) {
+        } else if (funcObj.func.pfunction.gapi.type == "function") {
+            if (!this.ops.validateFunc(funcObj.func.pclass.type, this.ops.pclassType)) return;
             this.genFuncFunction(funcObj, row);
         }
     }
@@ -1534,8 +1534,13 @@ class GraphVisitor{
             this.isPayable = true
         }
         let funcName = funcObj.func.pfunction.gapi.name + "_" + funcObj.i;
-        if (funcObj.func.pfunction.source) {
-            this.funcsources.push(`const ${funcName} = ${funcObj.func.pfunction.source}`);
+
+        let source = funcObj.func.pfunction.source;
+        if (!source && this.ops.addSource) {
+            source = this.ops.addSource(funcName, funcObj);
+        }
+        if (source) {
+            this.funcsources.push(`const ${funcName} = ${source}`);
         }
         // public variables from constructor arguments (contract addresses)
         if (this.ops.genConstr1) {
@@ -1547,7 +1552,7 @@ class GraphVisitor{
         }
         // code for constructor function, setting the public variables from arguments
         if (this.ops.genConstr3) {
-            this.genConstr3.push(funcName + this.ops.genConstr3 + funcName + ";")
+            this.genConstr3.push(this.ops.genConstr3(funcName, funcObj));
         }
         // _ids for constructor arguments in order (pclass ids)
         this.genConstr4.push(funcObj.func._id)
@@ -1578,7 +1583,7 @@ class GraphVisitor{
         if (funcObj.func.pfunction.gapi.payable) {
             rest1 = ".value(wei_value)"
         }
-        this.genF[grIndex] += this.ops.ansProxy(rest1, funcName, inputset);
+        this.genF[grIndex] += this.ops.ansProxy(rest1, funcName, inputset, funcObj);
         let outAssem = []
         let outputset = R.map((x)=>{
             // console.log(x)
@@ -1644,12 +1649,51 @@ class GraphVisitor{
 
 }
 
-function callInternalFunctionSolidity(payable, funcName, inputset) {
+function callInternalFunctionSolidity(payable, funcName, inputset, funcObj) {
     return `    answer42 = pipe_proxy.proxy${payable}(${funcName}, input42, 400000);\n`;
 }
 
-function callInternalFunctionOpenapi(payable, functionName, inputset) {
-    return `    result = await ${functionName}(${Object.values(inputset).join(",")});
+function callInternalFunctionJs(payable, funcName, inputset, funcObj) {
+    let result = '';
+    if (funcObj.func.pclass.deployment.pclassi.openapiid) {
+        result += `
+    baseUrl = baseUrl_${funcName};
+`
+    }
+    result += `    result = await ${funcName}(${Object.values(inputset).join(",")});
+`;
+    return result;
+}
+
+function addSourceJsFromSolidity(funcName, funcObj) {
+    if (funcObj.func.pclass.type  != visOptions.solidity.pclassType) {
+        return;
+    }
+    let gapi = funcObj.func.pfunction.gapi;
+    let inputs = gapi.inputs.map((input, i) => input.name || `${UNNAMED_INPUT}_i`);
+    let outputs = gapi.outputs.map((output, i) => output.name || `${UNNAMED_OUTPUT}_i`);
+    let returnValue = '';
+    if (outputs.length === 1) {
+        returnValue = ` {${outputs[0]}: output}`;
+    } else if (outputs.length > 1) {
+        returnValue = ` output`;
+    }
+    return `async function(${inputs.join(', ')}) {
+    const output = await contract_${funcName}.${gapi.name}(${inputs.join(', ')});
+    return${returnValue};
+}`;
+}
+
+function buildPClassVarsJs(funcName, funcObj) {
+    let pclassi = funcObj.func.pclass.deployment.pclassi;
+    if (pclassi.openapiid) {
+        return `const baseUrl_${funcName} = "http://${pclassi.host}${pclassi.basePath}";\n`;
+    }
+    const abi = funcObj.func.pclass.pclass.gapi;
+    return `
+const abi_${funcName} = ${JSON.stringify(abi)};
+const contractAddress_${funcName} = "${pclassi.address}";
+const contract_${funcName} = new ethers.Contract(contractAddress_${funcName}, abi_${funcName}, signer);
 `;
 }
 
@@ -1658,6 +1702,8 @@ var visOptions={
         type: "source",
         lang: "solidity",
         pclassType: "sol",
+        validateFunc: (type, pclassType) => type === pclassType,
+        addSource: null,
         "file_p0" : `pragma solidity ^0.4.24;
 pragma experimental ABIEncoderV2;
 
@@ -1679,7 +1725,7 @@ interface PipeProxy {
         "contract_p2": "}\n",
         "genConstr1": "    address public ",
         "genConstr2": "address _",
-        "genConstr3": " = _",
+        "genConstr3": (funcName, funcObj) => `${funcName} = _${funcName};`,
         "function_pp1": ") public payable ",
         // function returns from definition
         "function_ret0": " returns (",
@@ -1722,15 +1768,21 @@ interface PipeProxy {
         type: "source",
         lang: "javascript",
         pclassType: "js",
+        validateFunc: (type, pclassType) => type === pclassType || type === visOptions.solidity.pclassType,
+        addSource: addSourceJsFromSolidity,
         "file_p0" : `
-const baseUrl = 'http://192.168.1.141:5000/api/v1';
+let baseUrl;
 const httpClient = axios;
-const web3 = undefined;`,
+
+// Metamask
+const provider = new ethers.providers.Web3Provider(web3.currentProvider);
+const signer = provider.getSigner();
+`,
         "proxy": ``,
         "contract_p0": "",
         "contract_p1": ``,
         "contract_p2": "",
-
+        "genConstr3": buildPClassVarsJs,
         "function_pp1": ") {\n",
         // empty, we don't need to have returns in function definition
         "function_ret0": "",
@@ -1758,9 +1810,9 @@ const web3 = undefined;`,
         "sigFunc2": "",
         "inputSig1": "",
         "inputSig2": "",
-        "ansProxy": callInternalFunctionOpenapi,
+        "ansProxy": callInternalFunctionJs,
         "outputset": (type, name, i) => `o_${name}_${i};`,
-        "restFunc": (outputset, outAssem, outputs) => outAssem.map((out, i) => `    const ${out} = result.${outputs[i].name};`).join('\n'),
+        "restFunc": (outputset, outAssem, outputs) => outAssem.map((out, i) => `    const ${out} = result.${outputs[i].name || `${UNNAMED_OUTPUT}_i`};`).join('\n'),
         "assem": "",
         "intro0": `let `,
         "intro01": ` = null;`,


### PR DESCRIPTION
Solidity components, aside from generating Solidity source code, now also generate JS source code, based on ethers.js API.

E.g.

<img width="265" alt="screen shot 2019-02-26 at 9 49 46 pm" src="https://user-images.githubusercontent.com/4785356/53442927-1b667580-3a13-11e9-9ba1-7271f65168e4.png">


We generate:

- graph source:
```
[{"n":{"0":{"i":0,"id":"5c5f7c7a5243c00c35c5e60e"},"1":{"i":1,"id":"5c741f603e05b475e7b7331a"}},"e":[]}]
```

- Solidity source (note the missing function - if a JS component is present, we do not generate Solidity code for that function at all, as there is no use case for this; however, there can be another graph/tab with (only) Solidity components present and this one will be generated as a contract function)

```
pragma solidity ^0.4.24;
pragma experimental ABIEncoderV2;


interface PipeProxy {
    function proxy(
        address _to,
        bytes input_bytes,
        uint256 gas_value
    )
        payable
        external
        returns (bytes);
}

contract PipedContract {
    PipeProxy public pipe_proxy;

constructor(address _pipe_proxy, 
        ) public {
            pipe_proxy = PipeProxy(_pipe_proxy);
        
}
}
```

- JS code:
```

let baseUrl;
const httpClient = axios;

// Metamask
const provider = new ethers.providers.Web3Provider(web3.currentProvider);
const signer = provider.getSigner();


let i__owner_0 = null;
const baseUrl_stagePosition_get_1 = "http://192.168.1.107:5000/api/v1";


const abi_balanceOf_0 = [{"constant":false,"inputs":[{"name":"_to","type":"address"},{"name":"_value","type":"uint256"}],"name":"transfer","outputs":[{"name":"","type":"bool"}],"payable":false,"stateMutability":"nonpayable","type":"function"},{"anonymous":false,"inputs":[{"indexed":true,"name":"from","type":"address"},{"indexed":true,"name":"to","type":"address"},{"indexed":false,"name":"value","type":"uint256"}],"name":"Transfer","type":"event"},{"constant":true,"inputs":[{"name":"_owner","type":"address"}],"name":"balanceOf","outputs":[{"name":"","type":"uint256"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":true,"inputs":[],"name":"totalSupply","outputs":[{"name":"","type":"uint256"}],"payable":false,"stateMutability":"view","type":"function"}];
const contractAddress_balanceOf_0 = "0xC071Ba53fC099CC2050821d1f2215BDc3a216645";
const contract_balanceOf_0 = new ethers.Contract(contractAddress_balanceOf_0, abi_balanceOf_0, signer);


const stagePosition_get_1 = async function() {
    const url = `${baseUrl}/stage/position`;
    let Error;
    const StageStatus = (await httpClient.get(url)
        .catch((err) => Error = err))
        .data
    return {Error, StageStatus};
}
    ;
const balanceOf_0 = async function(_owner) {
    const output = await contract_balanceOf_0.balanceOf(_owner);
    return {o_unnamed_i: output};
};
(async function PipedFunction0(i__owner_0) {

    let result;


    baseUrl = baseUrl_stagePosition_get_1;
    result = await stagePosition_get_1();
    const o_Error_1 = result.Error;
    const o_StageStatus_1 = result.StageStatus;

    result = await balanceOf_0(i__owner_0);
    const o__0 = result.o_unnamed_i;

    console.log(o_Error_1, o_StageStatus_1, o__0);
    return {o_Error_1, o_StageStatus_1, o__0};

})(i__owner_0);
```

Note: we currently have issues with the Solidity contract constructor arguments generation, that should only contain addresses of contracts used in the Solidity generated functions.
Therefore, the above example currently generates the following constructor arguments:
```
"undefined","undefined","0xC071Ba53fC099CC2050821d1f2215BDc3a216645"
```
(first `"undefined"` is due to a bug in retrieving the `PipeProxy` contract address.
Issue to track this: https://github.com/pipeos-one/pipeline/issues/18