### PR TITLE
Client - fix payable WEI value in Solidity & add support for it in JS (generated code)

### DIFF
--- a/client/src/components/pipecanvas/pipecanvaslib.js
+++ b/client/src/components/pipecanvas/pipecanvaslib.js
@@ -1668,7 +1668,6 @@ class GraphVisitor{
         out = out + this.ops.const1 +this.genConstr2.join(", ") + this.ops.const2
         out = out + this.genConstr3.join("\n") + "\n"
         out = out + this.ops.const3
-        //out = out + this.intro2
 
         // Add helper functions - js
         if (this.funcsources.length) {
@@ -1831,13 +1830,6 @@ interface PipeProxy {
         "assem": " := mload(add(answer42, 32))",
         "intro1": "\n\nfunction PipedFunction",
         "intro11": "(",
-        "intro2": `) payable public {
-        bytes4 signature42;
-        bytes memory input42;
-        bytes memory answer42;
-        uint wei_value = msg.value;
-        address tx_sender = msg.sender;
-        `,
         "const1": "constructor(address _pipe_proxy, ",
         "const2": `
         ) public {
@@ -1902,7 +1894,6 @@ const signer = provider.getSigner();
         "intro1": `
 (async function PipedFunction`,
         "intro11": "(",
-        "intro2": "",
         "const1": "",
         "const2": ``,
         "const3": "",

--- a/client/src/components/pipecanvas/pipecanvaslib.js
+++ b/client/src/components/pipecanvas/pipecanvaslib.js
@@ -1693,7 +1693,8 @@ class GraphVisitor{
 function callInternalFunctionSolidity(funcName, inputset, funcObj) {
     let payable = '';
     if (funcObj.func.pfunction.gapi.payable) {
-        payable = `.value(${funcName}_${WEI_VALUE}_${funcObj.i})`;
+        let weiInput = Object.values(inputset).find(input => input.indexOf(WEI_VALUE) > -1);
+        payable = `.value(${weiInput})`;
     }
     return `    answer42 = pipe_proxy.proxy${payable}(${funcName}, input42, 400000);\n`;
 }

--- a/client/src/components/pipecanvas/pipecanvaslib.js
+++ b/client/src/components/pipecanvas/pipecanvaslib.js
@@ -1622,7 +1622,7 @@ class GraphVisitor{
         )
 
         if (this.ops.inputSig) {
-            this.genF[grIndex] += this.ops.inputSig(inputset);
+            this.genF[grIndex] += this.ops.inputSig(inputset, funcObj);
         }
 
         this.genF[grIndex] += this.ops.ansProxy(funcName, inputset, funcObj);
@@ -1699,13 +1699,17 @@ function callInternalFunctionSolidity(funcName, inputset, funcObj) {
     return `    answer42 = pipe_proxy.proxy${payable}(${funcName}, input42, 400000);\n`;
 }
 
-function setCallFuncSignature(inputset) {
+function setCallFuncSignature(inputset, funcObj) {
 
     let inputs = '';
     if (Object.values(inputset).length > 0) {
         inputs += ', ';
     }
-    inputs += Object.values(inputset).filter(input => input.indexOf(WEI_VALUE) < 0).join(", ");
+    if (funcObj.func.pfunction.gapi.payable) {
+        inputs += Object.values(inputset).filter(input => input.indexOf(WEI_VALUE) < 0).join(", ");
+    } else {
+        inputs += Object.values(inputset).join(", ");
+    }
     return `input42 = abi.encodeWithSelector(signature42${inputs});\n`;
 }
 

--- a/client/src/views/Pipe.vue
+++ b/client/src/views/Pipe.vue
@@ -498,6 +498,7 @@ export default {
         }
     },
     pipedLoadToRemix: function() {
+        let self = this;
         let name = `PipedContract_${randomId()}.sol`;
         this.loadToRemixCall(name, this.contractSource);
         this.pipedContracts[name] = null;
@@ -519,12 +520,12 @@ export default {
                     compiledContractProcess(result[0], function(contract) {
                         contract.tags.push('piped');
                         console.log('contract', contract);
-                        if (this.pipedContracts[contract.name]) {
+                        if (self.pipedContracts[contract.name]) {
                             if (confirm(`
                                 You have deployed ${contract.name}.
                                 Click "OK" if you want to save it on the Pipeos server.`)
                             ) {
-                                this.saveFromRemix(contract, {
+                                self.saveFromRemix(contract, {
                                     deployed: {
                                         address: data[0].contractAddress,
                                         chain_id: this.chain,


### PR DESCRIPTION
fixes https://github.com/pipeos-one/pipeline/issues/27
fixes https://github.com/pipeos-one/pipeline/issues/24

- add support for sending ETH value with an on-chain transaction in JS generated code
- fix how this was handled in the Solidity generated code:
Before, we could not have more than one payable function in a graph, because we would send `msg.value` to the first payable function.
Now, we add another input with `{type: 'uint256', name: <X>}`, where `<X> = canvasFunctionName + '_wei_value_' + inputIndex