### PR TITLE
Client - form for users to set the free graph inputs

### DIFF
--- a/client/src/components/abi/AbiFunction.vue
+++ b/client/src/components/abi/AbiFunction.vue
@@ -183,8 +183,11 @@ export default {
             if (this.errorMessages.length == 0) {
                 let args = [];
                 this.inputs.forEach(input => {
-                    if (typeof input.value == 'object') {
+                    if (typeof input.value === 'object') {
                         input.value = JsonArrayToString([input.value]);
+                    }
+                    if (typeof input.value === 'string') {
+                        input.value = `"${input.value}"`;
                     }
                     args.push(input);
                 });

--- a/client/src/components/abi/AbiFunction.vue
+++ b/client/src/components/abi/AbiFunction.vue
@@ -109,20 +109,14 @@ export default {
         inputsStr: function(inputs) {
             return inputs.map(input => `${input.type} ${input.name}`).join(',');
         },
-        validateArg(value, type, components=[]) {
+        validateArg(value, type, components=[], self) {
             if (type.indexOf('int') > -1) {
                 value = parseInt(value);
                 if (value === NaN) {
                     this.errorMessages.push(`Argument number ${i} should be ${input.type}`);
-                }
-                return value;
-            }
-
-            if (['string', 'address'].indexOf(type) > -1) {
-                if (
-                    value.indexOf('"') != 0 || value.lastIndexOf('"') != (value.length - 1)
-                ) {
-                    this.errorMessages.push(`Use quotes around strings and addresses`);
+                    if (self) {
+                        self.errorMessages = this.errorMessages;
+                    }
                 }
                 return value;
             }
@@ -138,6 +132,9 @@ export default {
                 }
                 catch(e) {
                     this.errorMessages.push(`Value does not have a valid JSON format`);
+                }
+                if (self) {
+                    self.errorMessages = this.errorMessages;
                 }
             }
             return value;

--- a/client/src/components/abi/AbiFunction.vue
+++ b/client/src/components/abi/AbiFunction.vue
@@ -1,65 +1,199 @@
 <template>
-    <form>
-      <vue-form-generator :schema="schema" :model="model" :options="formOptions">
-      </vue-form-generator>
-    </form>
+    <v-container>
+        <v-layout row wrap>
+            <v-flex xs4 v-if="!destructured">
+                <v-btn
+                    block depressed large
+                    :color="funcColor"
+                    @click="runFunction"
+                >
+                    {{abi.name}}
+                </v-btn>
+            </v-flex>
+            <v-flex xs7 offset-xs1>
+                <v-text-field
+                    v-if="!destructured && abi.inputs.length"
+                    v-model="functionArgs"
+                    outline
+                    height="60%"
+                    type="text"
+                    :placeholder="inputsStr(abi.inputs)"
+                    :hint="inputsStr(abi.inputs)"
+                    :error="error"
+                    :error-messages="errorMessages"
+                    :rules="rules"
+                    :append-outer-icon="abi.inputs.length > 1 || abi.inputs[0].type == 'tuple' ? 'fa-chevron-down' : ''"
+                    @click:append-outer="destructure"
+                    @change="argsValueChanged"
+                ></v-text-field>
+            </v-flex>
+        </v-layout>
+        <div v-if="destructured">
+            <v-layout row wrap>
+                <v-flex xs4>
+                    <v-btn
+                        block depressed large
+                        :color="funcColor"
+                        @click="runFunction"
+                    >
+                        {{abi.name}}
+                    </v-btn>
+                </v-flex>
+                <v-flex xs2 offset-xs6 class="text-xs-right">
+                    <v-btn flat icon @click="destructure">
+                        <v-icon>fa-chevron-up</v-icon>
+                    </v-btn>
+                </v-flex>
+            </v-layout>
+            <AbiIO
+                v-for="(input, i) in inputs"
+                :key="`input_${i}`"
+                :abi="input"
+                :validator="validateArg"
+                v-on:value-changed="internalInputChanged(...arguments, i)"
+            />
+        </div>
+        <v-layout row wrap>
+            <v-flex xs12
+                align-start
+                class="text-xs-left"
+                :id="'output_' + abi.name"
+            >
+            </v-flex>
+        </v-layout>
+        <v-divider></v-divider>
+    </v-container>
 </template>
 
 <script>
-import Vue from 'vue';
-import VueFormGenerator from 'vue-form-generator';
-import {inputToFormSchema, outputToFormSchema} from './ioToFormSchema.js';
+import AbiIO from './AbiIO';
+import {pfunctionColorClass, JsonArrayToString} from '../../utils/utils';
 
-Vue.use(VueFormGenerator);
+const colors = {payable: '#CDE0F2', nonconstant: '#E9DEDE'};
 
 export default {
     props: ['abi'],
+    components: {
+        AbiIO,
+    },
     data() {
         return {
-            schema: {},
-            model: {},
-            formOptions: {},
+            error: false,
+            errorMessages: [],
+            rules: [],
+            destructured: false,
+            functionArgs: '',
+            inputs: [],
+            outputs: [],
+            funcColor: '',
+            outputValues: null,
         }
     },
     created() {
-        this.setSchema();
+        this.setData();
     },
     watch: {
         abi: function() {
-            this.setSchema();
-        }
+            this.setData();
+        },
     },
     methods: {
-        setSchema: function() {
-            let schema = {groups: [], fields: []};
-            let submit_location = schema.fields;
-
-            if (this.abi.inputs && this.abi.inputs.length) {
-                schema.groups.push({
-                    legend: 'Inputs',
-                    fields: this.abi.inputs.map(io => inputToFormSchema(io)),
-                });
-                submit_location = schema.groups[0].fields;
-            }
-            if (this.abi.outputs && this.abi.outputs.length) {
-                schema.groups.push({
-                    legend: 'Outputs',
-                    fields: this.abi.outputs.map(io => outputToFormSchema(io)),
-                });
-            }
-
-            submit_location.push({
-                type: 'submit',
-                label: this.name,
-                caption: this.name,
-                validateBeforeSubmit: true,
-                onSubmit(model, schema2) {
-                    console.log('onSubmit', model, schema2);
+        setData: function() {
+            this.inputs = this.abi.inputs;
+            this.outputs = this.abi.outputs;
+            this.funcColor = colors[pfunctionColorClass(this.abi)];
+        },
+        destructure: function() {
+            this.destructured = !this.destructured;
+        },
+        inputsStr: function(inputs) {
+            return inputs.map(input => `${input.type} ${input.name}`).join(',');
+        },
+        validateArg(value, type, components=[]) {
+            if (type.indexOf('int') > -1) {
+                value = parseInt(value);
+                if (value === NaN) {
+                    this.errorMessages.push(`Argument number ${i} should be ${input.type}`);
                 }
-            });
+                return value;
+            }
 
-            this.schema = schema;
-        }
+            if (['string', 'address'].indexOf(type) > -1) {
+                if (
+                    value.indexOf('"') != 0 || value.lastIndexOf('"') != (value.length - 1)
+                ) {
+                    this.errorMessages.push(`Use quotes around strings and addresses`);
+                }
+                return value;
+            }
+
+            if (type === 'tuple') {
+                components.forEach(comp => {
+                    if (value[comp.name] === undefined) {
+                        this.errorMessages.push(`Missing field: ${comp.name}`);
+                    }
+                });
+                try {
+                    JSON.stringify(value);
+                }
+                catch(e) {
+                    this.errorMessages.push(`Value does not have a valid JSON format`);
+                }
+            }
+            return value;
+        },
+        stringToObjectArray: function() {
+            let args = [];
+
+            this.error = false;
+            this.errorMessages = [];
+
+            try {
+                args = JSON.parse(`[${this.functionArgs}]`);
+            }
+            catch(e) {
+                this.errorMessages.push('Use quotes around strings and addresses, make sure object keys have quotes');
+            }
+            return args;
+        },
+        setInputsFromString: function() {
+            let args = this.stringToObjectArray();
+            let inputs = this.inputs;
+
+            if (args.length != inputs.length) {
+                this.errorMessages.push(`Number of comma separated values should be ${inputs.length}`);
+            }
+            inputs.forEach((input, i) => {
+                inputs[i].value = this.validateArg(args[i], input.type, input.components);
+            });
+            this.inputs = inputs;
+        },
+        argsValueChanged: function(value) {
+            this.setInputsFromString();
+        },
+        inputsToString: function() {
+            this.functionArgs = JsonArrayToString(this.inputs.map(arg => arg.value));
+        },
+        internalInputChanged: function(value, index) {
+            let inputs = this.inputs;
+            inputs[index].value = value;
+            this.inputs = inputs;
+
+            this.inputsToString();
+        },
+        runFunction: function() {
+            this.setInputsFromString();
+            if (this.errorMessages.length == 0) {
+                let args = [];
+                this.inputs.forEach(input => {
+                    if (typeof input.value == 'object') {
+                        input.value = JsonArrayToString([input.value]);
+                    }
+                    args.push(input);
+                });
+                this.$emit('value-changed', args);
+            }
+        },
     }
 }
 </script>

--- a/client/src/components/abi/AbiFunctionForm.vue
+++ b/client/src/components/abi/AbiFunctionForm.vue
@@ -1,0 +1,66 @@
+<template>
+    <form>
+      <vue-form-generator :schema="schema" :model="model" :options="formOptions">
+      </vue-form-generator>
+    </form>
+</template>
+
+<script>
+import Vue from 'vue';
+import VueFormGenerator from 'vue-form-generator';
+import {inputToFormSchema, outputToFormSchema} from './ioToFormSchema.js';
+
+Vue.use(VueFormGenerator);
+
+export default {
+    props: ['abi'],
+    data() {
+        return {
+            schema: {},
+            model: {},
+            formOptions: {},
+        }
+    },
+    created() {
+        this.setSchema();
+    },
+    watch: {
+        abi: function() {
+            this.setSchema();
+        }
+    },
+    methods: {
+        setSchema: function() {
+            console.log('AbiFunction abi', this.abi);
+            let schema = {groups: [], fields: []};
+            let submit_location = schema.fields;
+
+            if (this.abi.inputs && this.abi.inputs.length) {
+                schema.groups.push({
+                    legend: 'Inputs',
+                    fields: this.abi.inputs.map(io => inputToFormSchema(io)),
+                });
+                submit_location = schema.groups[0].fields;
+            }
+            if (this.abi.outputs && this.abi.outputs.length) {
+                schema.groups.push({
+                    legend: 'Outputs',
+                    fields: this.abi.outputs.map(io => outputToFormSchema(io)),
+                });
+            }
+
+            submit_location.push({
+                type: 'submit',
+                label: this.name,
+                caption: this.name,
+                validateBeforeSubmit: true,
+                onSubmit(model, schema2) {
+                    console.log('onSubmit', model, schema2);
+                }
+            });
+
+            this.schema = schema;
+        }
+    }
+}
+</script>

--- a/client/src/components/abi/AbiIO.vue
+++ b/client/src/components/abi/AbiIO.vue
@@ -89,6 +89,8 @@ export default {
                 );
             } else if (typeof this.abi.value === 'object') {
                 this.inputValue = JsonArrayToString([this.abi.value]);
+            } else if (typeof this.abi.value === 'string') {
+                this.inputValue = `"${this.abi.value}"`;
             } else {
                 this.inputValue = this.abi.value;
             }

--- a/client/src/components/abi/AbiIO.vue
+++ b/client/src/components/abi/AbiIO.vue
@@ -1,0 +1,124 @@
+<template>
+    <div>
+        <v-layout row wrap>
+            <v-flex xs12>
+                <v-text-field
+                    v-if="!destructured"
+                    v-model="inputValue"
+                    full-width outline
+                    :type="inputType"
+                    :label="abi.name"
+                    :placeholder="abi.type"
+                    :hint="abi.type"
+                    :error="error"
+                    :error-messages="errorMessages"
+                    :rules="rules"
+                    :append-outer-icon="abi.components ? 'fa-chevron-down' : ''"
+                    @click:append-outer="destructure"
+                    @change="inputValueChanged"
+                ></v-text-field>
+                <v-card v-else>
+                    <v-layout row wrap>
+                        <v-flex xs2 offset-xs10 class="text-xs-right">
+                            <v-btn flat icon @click="destructure">
+                                <v-icon>fa-chevron-up</v-icon>
+                            </v-btn>
+                        </v-flex>
+                    </v-layout>
+                    <AbiIO
+                        v-for="(component, i) in components"
+                        :key="'component_' + i"
+                        :abi="component"
+                        :validator="validator"
+                        v-on:value-changed="internalInputChanged(...arguments, i)"
+                    />
+                </v-card>
+            </v-flex>
+        </v-layout>
+    </div>
+</template>
+
+<script>
+import {JsonArrayToString} from '../../utils/utils';
+
+const rules = {
+    address: (value) => value.length === 22,
+}
+
+export default {
+    name: 'AbiIO',
+    props: ['abi', 'validator'],
+    data() {
+        return {
+            inputType: 'text',
+            error: false,
+            errorMessages: [],
+            rules: [],
+            destructured: false,
+            inputValue: '',
+            components: [],
+        }
+    },
+    created() {
+        this.setIO();
+    },
+    watch: {
+        abi: function() {
+            this.setIO();
+        },
+    },
+    methods: {
+        setIO: function() {
+            this.components = this.abi.components || [];
+            this.setComponentsValuesFromAbi();
+            this.setInputValue();
+        },
+        setComponentsValuesFromAbi: function() {
+            let components = this.abi.components;
+            if (!components || !this.abi.value) return;
+
+            components.forEach((comp, i) => {
+                components[i].value = this.abi.value[comp.name];
+            });
+            this.components = components;
+        },
+        setInputValue: function() {
+            if (this.components.length) {
+                this.inputValue = JsonArrayToString(
+                    [this.getObjectFromComponents(this.components)]
+                );
+            } else if (typeof this.abi.value === 'object') {
+                this.inputValue = JsonArrayToString([this.abi.value]);
+            } else {
+                this.inputValue = this.abi.value;
+            }
+        },
+        getObjectFromComponents: function() {
+            let obj = {};
+            this.components.forEach(comp => {
+                obj[comp.name] = comp.value;
+            });
+            return obj;
+        },
+        destructure: function() {
+            this.destructured = !this.destructured;
+        },
+        inputValueChanged: function(value) {
+            try {
+                value = JSON.parse(value);
+            }
+            catch(e){};
+            this.$emit('value-changed', value);
+        },
+        internalInputChanged: function(value, index) {
+            this.components[index].value = this.validator(
+                value,
+                this.components[index].type,
+                this.components[index].components,
+            );
+            this.setInputValue();
+            this.$emit('value-changed', this.getObjectFromComponents());
+        }
+    },
+}
+</script>

--- a/client/src/components/abi/AbiIO.vue
+++ b/client/src/components/abi/AbiIO.vue
@@ -115,6 +115,7 @@ export default {
                 value,
                 this.components[index].type,
                 this.components[index].components,
+                this,
             );
             this.setInputValue();
             this.$emit('value-changed', this.getObjectFromComponents());

--- a/client/src/components/pipecanvas/pipecanvaslib.js
+++ b/client/src/components/pipecanvas/pipecanvaslib.js
@@ -792,10 +792,6 @@ function addPortFunc(i, o1, state1){
     let out2 = JSON.parse(JSON.stringify(out))
     // let out2 = out
 
-    // JSON.parse(JSON.stringify(
-    // console.log('addPortFunc', out2)
-    // out2.func.pfunction.gapi.outputs[0] = {name: "Lore", type:"olt"}
-    // JSON.parse(JSON.stringify(state1))
     out2.func.pfunction.gapi.outputs[0] = {name: state1.name, type: state1.type}
     // console.log('addPortFunc', out.state)
     // console.log('addPortFunc', JSON.stringify(out2))

--- a/client/src/components/pipecanvas/pipecanvaslib.js
+++ b/client/src/components/pipecanvas/pipecanvaslib.js
@@ -216,6 +216,7 @@ let edges;
 let g;
 const xr = 32;
 let startDrop; let endDrop;
+let containsEvent = {};
 
 const graph = {"n": [], "e": []};
 
@@ -294,6 +295,10 @@ export default class Graphs {
 
     getSource(lang) {
         return langs[lang]
+    }
+
+    containsEvent(index) {
+        return containsEvent[index];
     }
 }
 
@@ -432,10 +437,11 @@ function proc1() {
     //console.log(Object.assign({},pipe2.cgraphs[grIndex].n))
 
     //console.log(JSON.stringify(pipe2.cgraphs[grIndex].n))
-
+    delete containsEvent[grIndex];
     // events reverse i/o
     R.mapObjIndexed((x, key, all) => {
         if (x.func.pfunction.gapi.type == "event"){
+            containsEvent[grIndex] = true;
             if (x.func.pfunction.gapi.outputs === undefined) {
                 x.func.pfunction.gapi.outputs = []
             }
@@ -1406,7 +1412,6 @@ class GraphVisitor{
         this.minX = {}
         this.isPayable = false
         this.isNotConstant = false
-        this.containsEvent = false
     }
 
     renderFunc(funcObj, row){
@@ -1541,7 +1546,7 @@ class GraphVisitor{
         this.genF[grIndex] += this.genF2[grIndex]
 
         // Ending event promise if present
-        if (this.containsEvent && this.ops.function_ret3) {
+        if (containsEvent[grIndex] && this.ops.function_ret3) {
             this.genF[grIndex] += this.ops.function_ret3;
         }
 
@@ -1598,10 +1603,6 @@ class GraphVisitor{
             return;
         }
 
-        if (funcObj.func.pfunction.gapi.type === 'event') {
-            if (this.containsEvent) return;
-            this.containsEvent = true;
-        }
         this.genFuncFunction(funcObj, row);
     }
 

--- a/client/src/components/pipecanvas/pipecanvaslib.js
+++ b/client/src/components/pipecanvas/pipecanvaslib.js
@@ -1559,7 +1559,9 @@ class GraphVisitor{
                 let name = `i_${input.name}_${funcObject.i}`;
                 this.abi.inputs.forEach((pipedin, i) => {
                     if (pipedin.name === name) {
-                        this.abi.inputs[i] = Object.assign(input, this.abi.inputs[i]);
+                        this.abi.inputs[i] = Object.assign(
+                            JSON.parse(JSON.stringify(input)), this.abi.inputs[i]
+                        );
                     }
                 });
 

--- a/client/src/utils/utils.js
+++ b/client/src/utils/utils.js
@@ -6,7 +6,7 @@ export function pfunctionColorClass(gapi) {
     let colorClass = '';
     if (gapi.type === 'event') {
         colorClass = 'event';
-    } else if (gapi.type === 'payable') {
+    } else if (gapi.payable) {
         colorClass = 'payable';
     } else if (!gapi.constant) {
         colorClass = 'nonconstant';
@@ -31,6 +31,15 @@ export function linkReferencesSolcToEthPM(linkReferences={}) {
         });
     });
     return lreferences;
+}
+
+export const JsonArrayToString = function (json) {
+    let functionArgs = JSON.stringify(json);
+    functionArgs = functionArgs.substring(
+        1,
+        functionArgs.length - 1,
+    ).replace(/\\"/g, '"');
+    return functionArgs;
 }
 
 export function compiledContractProcess(compiled, callback) {

--- a/client/src/views/Pipe.vue
+++ b/client/src/views/Pipe.vue
@@ -77,6 +77,7 @@
                 :deploymentInfo="deploymentInfo"
                 :jsSource="jsSource"
                 :graphSource="graphSource"
+                :graphsAbi="graphsAbi"
                 v-on:load-remix="pipedLoadToRemix"
             />
         </swiper-slide>
@@ -174,6 +175,7 @@ export default {
         deploymentInfo: '',
         jsSource: '',
         graphSource: '',
+        graphsAbi: null,
         graphInstance: null,
         pipedContracts: {},
     };
@@ -249,6 +251,7 @@ export default {
                     this.contractSource = this.graphInstance.getSource('solidity');
                     this.graphSource = JSON.stringify(this.graphInstance.getSource('graphs'));
                     this.jsSource = this.graphInstance.getSource('javascript');
+                    this.graphsAbi = this.graphInstance.getSource('abi');
                     this.deploymentInfo = [Pipeos.contracts.PipeProxy.addresses[this.chain]]
                         .concat(this.graphInstance.getSource('constructor').map(function_id => {
                             let contract_address;

--- a/client/src/views/Pipe.vue
+++ b/client/src/views/Pipe.vue
@@ -326,10 +326,7 @@ export default {
     },
     onFunctionToggle: function (pfunction) {
         if (pfunction.pfunction.gapi.type === 'event') {
-            let index = this.selectedFunctions[this.activeCanvas].findIndex(func => {
-                return func.pfunction.gapi.type === 'event';
-            });
-            if (index > -1) {
+            if (this.graphInstance.containsEvent(this.activeCanvas)) {
                 alert('There can only be one event per graph/tab. You can add another graph/tab by clicking the + button.');
                 return;
             }

--- a/client/src/views/PipeFunction.vue
+++ b/client/src/views/PipeFunction.vue
@@ -1,16 +1,16 @@
 <template>
-    <AbiFunction :abi="abi"/>
+    <AbiFunctionForm :abi="abi"/>
 </template>
 
 <script>
 import Vue from 'vue';
 import Pipeos from '../namespace/namespace';
-import AbiFunction from '../components/abi/AbiFunction';
+import AbiFunctionForm from '../components/abi/AbiFunctionForm';
 
 const api = Pipeos.pipeserver.api.function;
 
 export default {
-    components: {AbiFunction},
+    components: {AbiFunctionForm},
     data() {
         return {
             abi: {},


### PR DESCRIPTION
fixes https://github.com/pipeos-one/pipeline/issues/22

- add a form for users to set the free graph inputs for running the generated code. Now a user has a form for free inputs and the script output is also shown when returned.
- fix event component - allow adding an event component after the previous one was removed.

Supports destructuring of arguments in the form:
- if function receives > 1 arguments, you can open each argument in its own text field
- if an argument is an object, you can open each key:value pair in its own text field

<img width="1051" alt="screen shot 2019-03-02 at 9 33 18 am" src="https://user-images.githubusercontent.com/4785356/53679583-84c5dd00-3cce-11e9-83e7-66315bf5a52a.png">
