### PR TITLE
Client - add deployment values as user inputs in the script form

### DIFF
--- a/client/src/components/abi/AbiFunction.vue
+++ b/client/src/components/abi/AbiFunction.vue
@@ -186,7 +186,7 @@ export default {
                     if (typeof input.value === 'object') {
                         input.value = JsonArrayToString([input.value]);
                     }
-                    if (typeof input.value === 'string') {
+                    if (typeof input.value === 'string' && input.type != 'tuple') {
                         input.value = `"${input.value}"`;
                     }
                     args.push(input);

--- a/client/src/components/pipecanvas/pipecanvaslib.js
+++ b/client/src/components/pipecanvas/pipecanvaslib.js
@@ -14,6 +14,7 @@ const ARGUMENT_NAMES = /([^\s,]+)/g;
 const UNNAMED_INPUT = 'i_unnamed';
 const UNNAMED_OUTPUT = 'o_unnamed';
 const WEI_VALUE  = 'wei_value';
+const DEPLOYMENT_VAR = 'deployment';
 
 function getParamNames(func) {
     const fnStr = func.toString().replace(STRIP_COMMENTS, '');
@@ -1749,7 +1750,7 @@ function callInternalFunctionJs(funcName, inputset, funcObj) {
     }
     if (funcObj.func.pclass.deployment.pclassi.openapiid) {
         result += `
-    baseUrl = baseUrl_${funcName};
+    baseUrl = ${DEPLOYMENT_VAR}_${funcName};
 `
     }
     result += `    result = await ${funcName}(${Object.values(inputset).join(",")});
@@ -1802,13 +1803,13 @@ function addSourceJsFromSolidity(funcName, funcObj) {
 function buildPClassVarsJs(funcName, funcObj) {
     let pclassi = funcObj.func.pclass.deployment.pclassi;
     if (pclassi.openapiid) {
-        return `const baseUrl_${funcName} = "http://${pclassi.host}${pclassi.basePath}";\n`;
+        return `const ${DEPLOYMENT_VAR}_${funcName} = "http://${pclassi.host}${pclassi.basePath}";\n`;
     }
     const abi = funcObj.func.pclass.pclass.gapi;
     return `
 const abi_${funcName} = ${JSON.stringify(abi)};
-const contractAddress_${funcName} = "${pclassi.address}";
-const contract_${funcName} = new ethers.Contract(contractAddress_${funcName}, abi_${funcName}, signer);
+const ${DEPLOYMENT_VAR}_${funcName} = "${pclassi.address}";
+const contract_${funcName} = new ethers.Contract(${DEPLOYMENT_VAR}_${funcName}, abi_${funcName}, signer);
 `;
 }
 

--- a/client/src/components/pipecanvas/pipecanvaslib.js
+++ b/client/src/components/pipecanvas/pipecanvaslib.js
@@ -1384,7 +1384,7 @@ class GraphVisitor{
         // code for constructor function, setting the public variables from arguments
         this.genConstr3 = []
         // _ids for constructor arguments in order (pclass ids)
-        this.genConstr4 = []
+        this.genConstr4 = {}
         this.genG = []
         // function sources that should be made available - js
         this.funcsources = []
@@ -1634,7 +1634,7 @@ class GraphVisitor{
             this.genConstr3.push(this.ops.genConstr3(funcName, funcObj));
         }
         // _ids for constructor arguments in order (pclass ids)
-        this.genConstr4.push(funcObj.func._id)
+        this.genConstr4[funcName] = funcObj.func._id;
 
         let f = this.genF[grIndex] || "";
         this.genF[grIndex] = f + "\n";

--- a/client/src/views/Pipe.vue
+++ b/client/src/views/Pipe.vue
@@ -231,6 +231,9 @@ export default {
             console.log('response', response);
             let pclasses = response.data.pclasses.map(pclass => {
                 pclass.deployment = response.data.pclassii.find(depl => depl.pclassid == pclass._id);
+                if (!pclass.deployment) {
+                    pclass.deployment = {pclassi: {address: `Deployment address for ${pclass.name} not found.`}};
+                }
                 return pclass;
             });
             this.linkContainersFunctions(response.data.pfunctions, pclasses);

--- a/client/src/views/Pipe.vue
+++ b/client/src/views/Pipe.vue
@@ -176,7 +176,7 @@ export default {
         filterOptions,
         pipeJs: {},
         contractSource: '',
-        deploymentInfo: '',
+        deploymentInfo: [],
         jsSource: '',
         graphSource: '',
         graphsAbi: null,
@@ -254,21 +254,36 @@ export default {
             this.selectedFunctions,
             {
                 onGraphChange: () => {
+                    let deployment_info;
                     this.contractSource = this.graphInstance.getSource('solidity');
                     this.graphSource = JSON.stringify(this.graphInstance.getSource('graphs'));
                     this.jsSource = this.graphInstance.getSource('javascript');
                     this.graphsAbi = this.graphInstance.getSource('abi');
-                    this.deploymentInfo = [Pipeos.contracts.PipeProxy.addresses[this.chain]]
-                        .concat(this.graphInstance.getSource('constructor').map(function_id => {
+                    deployment_info = this.graphInstance.getSource('constructor');
+                    this.deploymentInfo = [{
+                        funcName: 'proxy',
+                        deployment: Pipeos.contracts.PipeProxy.addresses[this.chain],
+                        contractName: 'PipeProxy',
+                    }];
+
+                    this.deploymentInfo = this.deploymentInfo.concat(
+                        Object.keys(deployment_info).map(funcName => {
+                            let function_id = deployment_info[funcName]
                             let contract_address;
                             this.selectedFunctions.forEach(pipedFunction => {
                                 let functionObj = pipedFunction.find(func => func._id == function_id);
                                 if (functionObj) {
-                                    contract_address = functionObj.pclass.deployment.pclassi.address;
+                                    let deployment = functionObj.pclass.deployment.pclassi;
+                                    contract_address = {
+                                        funcName,
+                                        deployment: deployment.openapiid ? `${deployment.host}${deployment.basePath}` : deployment.address,
+                                        contractName: functionObj.pclass.name,
+                                    };
                                 }
                             });
                             return contract_address;
-                        })).map(address => `"${address}"`).join(',');
+                        })
+                    );
                     console.log('this.deploymentInfo', this.deploymentInfo);
                 },
                 onGraphFunctionRemove: (grIndex, nodes) => {

--- a/client/src/views/Pipe.vue
+++ b/client/src/views/Pipe.vue
@@ -276,7 +276,7 @@ export default {
                                     let deployment = functionObj.pclass.deployment.pclassi;
                                     contract_address = {
                                         funcName,
-                                        deployment: deployment.openapiid ? `${deployment.host}${deployment.basePath}` : deployment.address,
+                                        deployment: deployment.openapiid ? `http://${deployment.host}${deployment.basePath}` : deployment.address,
                                         contractName: functionObj.pclass.name,
                                     };
                                 }


### PR DESCRIPTION
Now users can change deployment values (contract addresses, OpenAPI urls) in the free input form.