### PR TITLE
Server - temporary dependency fix

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -47,22 +47,22 @@
     "src"
   ],
   "dependencies": {
-    "@loopback/boot": "^1.0.7",
-    "@loopback/context": "^1.3.0",
-    "@loopback/core": "^1.1.2",
-    "@loopback/dist-util": "^0.4.0",
-    "@loopback/openapi-v3": "^1.1.4",
-    "@loopback/repository": "^1.0.6",
-    "@loopback/rest": "^1.5.1",
-    "@loopback/service-proxy": "^1.0.4",
-    "@types/swagger-schema-official": "^2.0.14",
-    "loopback-connector-mongodb": "^3.9.2",
-    "loopback-connector-rest": "^3.4.1",
+    "@loopback/boot": "1.0.7",
+    "@loopback/context": "1.3.0",
+    "@loopback/core": "1.1.2",
+    "@loopback/dist-util": "0.4.0",
+    "@loopback/openapi-v3": "1.1.4",
+    "@loopback/repository": "1.0.6",
+    "@loopback/rest": "1.5.1",
+    "@loopback/service-proxy": "1.0.4",
+    "@types/swagger-schema-official": "2.0.14",
+    "loopback-connector-mongodb": "3.9.2",
+    "loopback-connector-rest": "3.4.1",
     "solc": "^0.4.25"
   },
   "devDependencies": {
-    "@loopback/build": "^1.0.2",
-    "@loopback/testlab": "^1.0.2",
-    "@types/node": "^10.12.15"
+    "@loopback/build": "1.0.2",
+    "@loopback/testlab": "1.0.2",
+    "@types/node": "10.12.15"
   }
 }


### PR DESCRIPTION
Errors that prompted this:

```
src/controllers/pclass.controller.ts:168:65 - error TS2339: Property 'chainids' does not exist on type 'Where<PClass>'.
  Property 'chainids' does not exist on type 'AndClause<PClass>'.

168     if (filter && filter.where && (<Where<PClass>>filter.where).chainids) {
                                                                    ~~~~~~~~

src/controllers/pclass.controller.ts:169:48 - error TS2339: Property 'chainids' does not exist on type 'Where<AnyObject>'.
  Property 'chainids' does not exist on type 'Condition<AnyObject>'.

169         pclassi_queries.push({or: filter.where.chainids.inq.map((chainid: string) => {
```