### PR TITLE
Fix pipecanvaslib function name for swarm OpenApi urls

### DIFF
--- a/client/src/components/abi/AbiFunction.vue
+++ b/client/src/components/abi/AbiFunction.vue
@@ -56,7 +56,7 @@
         <v-layout row wrap>
             <v-flex xs12
                 align-start
-                class="text-xs-left"
+                class="text-xs-left abiFunctionOutput"
                 :id="'output_' + abi.name"
             >
             </v-flex>

--- a/client/src/components/pipeapp/PipeApp.vue
+++ b/client/src/components/pipeapp/PipeApp.vue
@@ -91,7 +91,7 @@
                         <v-card>
                             <v-flex xs12
                                 v-for="(instance, i) in deploymentInfoMap"
-                                :key="i"
+                                :key="`deployment_${i}`"
                             >
                                 <v-text-field
                                     :ref="instance.funcName"
@@ -107,7 +107,7 @@
                             <AbiFunction
                                 v-if="graphsAbi.length"
                                 v-for="(funcAbi, i) in graphsAbi"
-                                :key="i"
+                                :key="`function_${i}`"
                                 :abi="funcAbi"
                                 v-on:value-changed="jsArgumentsChange"
                             />

--- a/client/src/components/pipeapp/PipeApp.vue
+++ b/client/src/components/pipeapp/PipeApp.vue
@@ -175,6 +175,12 @@ export default {
         deploymentInfo: function() {
             this.setDeploymentInfo();
         },
+        dialog: function() {
+            let elements = document.getElementsByClassName('abiFunctionOutput');
+            for (let i = 0; i < elements.length; i++) {
+                elements[i].innerHTML = '';
+            };
+        },
     },
     methods: {
         setDeploymentInfo: function() {

--- a/client/src/components/pipecanvas/pipecanvaslib.js
+++ b/client/src/components/pipecanvas/pipecanvaslib.js
@@ -1603,8 +1603,12 @@ class GraphVisitor{
         this.genFuncFunction(funcObj, row);
     }
 
+    prepFuncName(name) {
+        return name.replace(/:/g, '').replace(/-/g, '');
+    }
+
     genFuncFunction(funcObj, row) {
-        let funcName = funcObj.func.pfunction.gapi.name + "_" + funcObj.i;
+        let funcName = this.prepFuncName(funcObj.func.pfunction.gapi.name) + "_" + funcObj.i;
 
         if (funcObj.func.pfunction.gapi.payable) {
             this.isPayable = true;


### PR DESCRIPTION
- fixes pipecanvaslib function name for swarm OpenApi urls: replace `:` & `-` with `""`
- also clears outputs when the user opens the form in PipeApp: remove previous output results