### PR TITLE
Fix swarm upload

### DIFF
--- a/client/src/components/ExportToEthPM.vue
+++ b/client/src/components/ExportToEthPM.vue
@@ -7,16 +7,18 @@
                 height="60%"
                 type="text"
                 label="package name"
-                placeholder="package name"
+                placeholder="Package Name"
                 :rules=rulesSimple
             ></v-text-field>
             <v-text-field
                 v-model="version"
                 outline
+                persistent-hint
                 height="60%"
                 type="text"
                 label="version"
                 placeholder="1.0.0"
+                hint="1.0.0"
                 :rules=rulesSimple
             ></v-text-field>
             <v-text-field
@@ -25,7 +27,7 @@
                 height="60%"
                 type="text"
                 label="license"
-                placeholder="MIT"
+                hint="MIT"
                 :rules=rulesSimple
             ></v-text-field>
             <v-text-field
@@ -40,21 +42,23 @@
             <v-text-field
                 v-model="authors"
                 outline
+                persistent-hint
                 height="60%"
                 type="text"
                 label="authors"
                 placeholder="Name1 <name1@email.com>,Name2 <name2@email.com>"
-                hint="Comma separated author names"
+                hint="Name1 <@email.com>,Name2 <@email.com>"
                 :rules=rulesSimple
             ></v-text-field>
             <v-text-field
                 v-model="keywords"
                 outline
+                persistent-hint
                 height="60%"
                 type="text"
                 label="keywords"
                 placeholder="keyword1,keyword2"
-                hint="Comma separated strings"
+                hint="keyword1,keyword2"
                 :rules=rulesSimple
             ></v-text-field>
         </v-flex>

--- a/client/src/components/ExportToEthPM.vue
+++ b/client/src/components/ExportToEthPM.vue
@@ -42,7 +42,7 @@
                 outline
                 height="60%"
                 type="text"
-                label="keywords"
+                label="authors"
                 placeholder="Name1 <name1@email.com>,Name2 <name2@email.com>"
                 hint="Comma separated author names"
                 :rules=rulesSimple

--- a/server/src/controllers/dstorage.controller.ts
+++ b/server/src/controllers/dstorage.controller.ts
@@ -26,14 +26,14 @@ export class DStorageController {
     );
   }
 
-  async get(type: DStorageType, hash: string): Promise<any> {
+  async get(type: DStorageType, hash: string, contentType: string): Promise<any> {
     let storage;
     if (type === 'ipfs') {
         storage = await this.ipfs();
         return storage.ipfs.get(hash);
     } else if (type === 'swarm') {
         storage = await this.swarm();
-        return storage.swarm.get(hash);
+        return storage.swarm[`get${contentType}`](hash);
     }
   }
 

--- a/server/src/controllers/dstorage.controller.ts
+++ b/server/src/controllers/dstorage.controller.ts
@@ -37,14 +37,14 @@ export class DStorageController {
     }
   }
 
-  async post(type: DStorageType, content: string): Promise<any> {
+  async post(type: DStorageType, content: string, contentType: string): Promise<any> {
     let storage;
     if (type === 'ipfs') {
         storage = await this.ipfs();
         return storage.ipfs.post(content);
     } else if (type === 'swarm') {
         storage = await this.swarm();
-        return storage.swarm.post(content);
+        return storage.swarm[`post${contentType}`](content);
     }
   }
 }

--- a/server/src/controllers/dstorage.controller.ts
+++ b/server/src/controllers/dstorage.controller.ts
@@ -41,14 +41,10 @@ export class DStorageController {
     let storage;
     if (type === 'ipfs') {
         storage = await this.ipfs();
-        return storage.ipfs.post(content).catch(error => {
-            throw new HttpErrors.InternalServerError(error);
-        });
+        return storage.ipfs.post(content);
     } else if (type === 'swarm') {
         storage = await this.swarm();
-        return storage.swarm.post(content).catch(error => {
-            throw new HttpErrors.InternalServerError(error);
-        });
+        return storage.swarm.post(content);
     }
   }
 }

--- a/server/src/controllers/package.controller.ts
+++ b/server/src/controllers/package.controller.ts
@@ -276,12 +276,12 @@ export class PackageController {
   }
 
   async insertFromStorage(type: DStorageType, hash: string): Promise<Package> {
-    let dstorage, ppackage, newPackage;
+    let dstorage, ppackage, newPackage: any;
     let json: any, package_json: EthPMPackageJson;
 
     dstorage = new DStorageController();
 
-    json = (await dstorage.get(type, hash))[0];
+    json = (await dstorage.get(type, hash, 'Json'))[0];
     if (!json) {
         throw new HttpErrors.NotFound('Package.json not found');
     }
@@ -301,7 +301,10 @@ export class PackageController {
         storage: {type, hash},
     };
     newPackage = await this.packageRepository.create(ppackage);
-    return await this.importFromEthpm(newPackage._id);
+    return await this.importFromEthpm(newPackage._id).catch(async (error) => {
+        await this.packageRepository.deleteById(newPackage._id);
+        throw error;
+    });
   }
 
   @get('/package/import/{id}', {
@@ -326,12 +329,16 @@ export class PackageController {
     let pclassiController = new PClassIController(await this.packageRepository.pclassi);
 
     ppackage = await this.findById(id);
-    if (!ppackage) throw new HttpErrors.NotFound('Game not found');
+    if (!ppackage) throw new HttpErrors.NotFound('Package not found');
     if (ppackage.package) {
         // TODO return pclasses, deployments and pfunctions
         return ppackage;
     }
-    package_json = JSON.parse(ppackage.package_json);
+    try {
+        package_json = JSON.parse(ppackage.package_json);
+    } catch(e) {
+        throw new HttpErrors.InternalServerError(`Cannot parse package.json for _id ${id}`);
+    }
 
     tags.push(package_json.package_name);
     tags.push('ethpm');
@@ -342,27 +349,33 @@ export class PackageController {
     sources = await Promise.all(Object.entries(package_json.sources).map(async (entry: any): Promise<number> => {
         let relative_path: string = entry[0];
         let source: string = entry[1];
-        let source_entry: any, source_string: string, dstorage_link: any;
+        let source_entry: any, source_string: any, dstorage_link: any;
+        let storageType: DStorageType;
         let dstorage;
 
         source_entry = {relative_path};
-        dstorage_link = source.match(/^(ipfs|bzz)/g);
+
+        // TODO better abstractions for protocols
+        dstorage_link = source.match(/^(ipfs|bzz|bzz-raw)/g);
+        storageType = dstorage_link[0] === 'ipfs' ? 'ipfs' : 'swarm';
 
         if (dstorage_link) {
             source_entry.storage = {
-                type: dstorage_link[0],
-                hash: source.replace(/^(ipfs|bzz):\/\//g, ''),
+                type: storageType,
+                hash: source.replace(/^(ipfs|bzz|bzz-raw):\/\//g, ''),
             }
             dstorage = new DStorageController();
 
-            source_string = (await dstorage.get(
+            source_string = await dstorage.get(
                 source_entry.storage.type,
                 source_entry.storage.hash,
-            ).catch((error) => { throw(error) }))[0];
-            if (!source_string) {
+                'Text',
+            );
+
+            if (!source_string || !source_string[0]) {
                 throw new HttpErrors.NotFound(`Source for ${source} not found`);
             }
-            source_entry.source = source_string;
+            source_entry.source = source_string[0];
         }
 
         if (!source_entry.source) {

--- a/server/src/datasources/swarm.datasource.ts
+++ b/server/src/datasources/swarm.datasource.ts
@@ -8,7 +8,7 @@ export const SwarmDataSource: juggler.DataSource = new juggler.DataSource({
   options: {
     headers: {
       accept: 'application/json',
-      'content-type': 'application/json',
+      'content-type': 'text/html; charset=utf-8',
     },
   },
   operations: [
@@ -26,11 +26,30 @@ export const SwarmDataSource: juggler.DataSource = new juggler.DataSource({
       template: {
         method: 'POST',
         url: `${swarmGateway}/bzz-raw:/`,
-        form: '{^content}',
+        body: '{^content}',
+        headers: {
+          accept: 'text/html',
+          'content-type': 'text/plain; charset=utf-8',
+        },
         responsePath: '$',
       },
       functions: {
-        post: ['content'],
+        postText: ['content'],
+      },
+    },
+    {
+      template: {
+        method: 'POST',
+        url: `${swarmGateway}/bzz-raw:/`,
+        form: '{^content}',
+        headers: {
+            accept: "application/json",
+            "content-type": "application/json"
+        },
+        responsePath: '$',
+      },
+      functions: {
+        postJson: ['content'],
       },
     },
   ],

--- a/server/src/datasources/swarm.datasource.ts
+++ b/server/src/datasources/swarm.datasource.ts
@@ -16,10 +16,28 @@ export const SwarmDataSource: juggler.DataSource = new juggler.DataSource({
       template: {
         method: 'GET',
         url: `${swarmGateway}/bzz-raw:/{hash}`,
+        headers: {
+            accept: "application/json",
+            "content-type": "application/json"
+        },
         responsePath: '$',
       },
       functions: {
-        get: ['hash'],
+        getJson: ['hash'],
+      },
+    },
+    {
+      template: {
+        method: 'GET',
+        url: `${swarmGateway}/bzz-raw:/{hash}`,
+        headers: {
+            accept: "text/plain",
+            "content-type": "text/plain; charset=utf-8"
+        },
+        responsePath: '$',
+      },
+      functions: {
+        getText: ['hash'],
       },
     },
     {

--- a/server/src/utils/dstorage.ts
+++ b/server/src/utils/dstorage.ts
@@ -6,19 +6,21 @@ const UPLOAD_RETRIES = 40;
 export const retryDstorageUpload = async (
     type: DStorageType,
     content: string,
+    contentType: string = 'Json',
     retries: number = 0,
 ): Promise<string | undefined> => {
     let hash;
     const dstorage = new DStorageController();
+
     try {
-        hash = (await dstorage.post(type, content))[0];
+        hash = (await dstorage.post(type, content, contentType))[0];
     } catch(error) {
         retries += 1;
     }
-    console.log('--- retryDstorageUpload', type, retries, hash);
+    console.log('--- retryDstorageUpload', type, retries, hash, contentType);
     if (!hash && retries <= UPLOAD_RETRIES) {
         await waitAsync(500);
-        return retryDstorageUpload(type, content, retries);
+        return retryDstorageUpload(type, content, contentType, retries);
     }
     return hash;
 }

--- a/server/src/utils/dstorage.ts
+++ b/server/src/utils/dstorage.ts
@@ -1,0 +1,32 @@
+import {DStorageType} from '../interfaces';
+import {DStorageController} from '../controllers/dstorage.controller';
+
+const UPLOAD_RETRIES = 40;
+
+export const retryDstorageUpload = async (
+    type: DStorageType,
+    content: string,
+    retries: number = 0,
+): Promise<string | undefined> => {
+    let hash;
+    const dstorage = new DStorageController();
+    try {
+        hash = (await dstorage.post(type, content))[0];
+    } catch(error) {
+        retries += 1;
+    }
+    console.log('--- retryDstorageUpload', type, retries, hash);
+    if (!hash && retries <= UPLOAD_RETRIES) {
+        await waitAsync(500);
+        return retryDstorageUpload(type, content, retries);
+    }
+    return hash;
+}
+
+export const dsProtocol = (type: DStorageType): string => {
+    return `${type == 'swarm' ? 'bzz-raw' : 'ipfs'}://`;
+}
+
+async function waitAsync(delay: number) {
+    return new Promise(resolve => setTimeout(resolve, delay));
+}

--- a/server/src/utils/ethpm.ts
+++ b/server/src/utils/ethpm.ts
@@ -1,21 +1,39 @@
 import {EthPMPackageJson} from '../interfaces/ethpm';
 import {chainIdToBip122Uri} from './chain';
+import {dsProtocol} from './dstorage';
 
-export let pipeToEthpm = (ppackage: any, pclasses: any, pclassii: any): EthPMPackageJson => {
+export let pipeToEthpm = async (
+    ppackage: any,
+    pclasses: any,
+    pclassii: any,
+    uploadCallback: any,
+): Promise<EthPMPackageJson> => {
     let contract_types: any = {}, deployments: any = {}, sources: any = {};
     let pclassidToAlias: any = {};
 
-    pclasses.forEach((pclass: any) => {
+    for (let i: number = 0; i < pclasses.length; i++) {
+        let pclass = pclasses[i];
         let contract_alias = pclass.name;
         pclassidToAlias[pclass._id] = contract_alias;
 
-        pclass.pclass.sources.forEach((source: any) => {
+        for (let j: number = 0; j < pclass.pclass.sources.length; j++) {
+            let source = pclass.pclass.sources[j];
             if (!sources[source.relative_path]) {
-                sources[source.relative_path] = source.storage ?
-                    `${source.storage.type}://${source.storage.hash}` :
-                    source.source;
+                if (!source.storage) {
+                    // We upload the source to swarm
+                    let hash = await uploadCallback('swarm', source.source);
+                    if (hash) {
+                        source.storage = {
+                            type: 'swarm',
+                            hash,
+                        }
+                    }
+                }
+                sources[source.relative_path] = source.storage
+                    ? `${dsProtocol(source.storage.type)}${source.storage.hash}`
+                    : source.source;
             }
-        });
+        };
 
         contract_types[contract_alias] = {
             contract_name: contract_alias != pclass.pclass.name ? pclass.pclass.name : undefined,
@@ -25,7 +43,7 @@ export let pipeToEthpm = (ppackage: any, pclasses: any, pclassii: any): EthPMPac
             natspec: pclass.pclass.natspec,
             compiler: pclass.pclass.compiler,
         }
-    });
+    };
 
     pclassii.forEach((pclassi: any) => {
         let bip122_uri = pclassi.pclassi.bip122_uri || chainIdToBip122Uri(pclassi.pclassi.chain_id, pclassi.pclassi.block);

--- a/server/src/utils/ethpm.ts
+++ b/server/src/utils/ethpm.ts
@@ -21,7 +21,7 @@ export let pipeToEthpm = async (
             if (!sources[source.relative_path]) {
                 if (!source.storage) {
                     // We upload the source to swarm
-                    let hash = await uploadCallback('swarm', source.source);
+                    let hash = await uploadCallback('swarm', source.source, 'Text');
                     if (hash) {
                         source.storage = {
                             type: 'swarm',


### PR DESCRIPTION
fixes https://github.com/pipeos-one/pipeline/issues/59

Add retries in case of failure.

Fix swarm upload of text and json sources:
- Headers and encoding were incorrect for text sources and `(` was replaced with `%28`, `)` was replaced with `%29`.
- Now, JSON content is uploaded differently than `text/plain`.

Fix swarm content retrieval for text/plain.

EthPM upload form - add persistent hints